### PR TITLE
random: Add entropy bits to the pool

### DIFF
--- a/drivers/char/random.c
+++ b/drivers/char/random.c
@@ -1958,6 +1958,7 @@ SYSCALL_DEFINE3(getrandom, char __user *, buf, size_t, count,
 	if (!crng_ready()) {
 		if (flags & GRND_NONBLOCK)
 			return -EAGAIN;
+		credit_entropy_bits(&input_pool, 256);
 		crng_wait_ready();
 		if (signal_pending(current))
 			return -ERESTARTSYS;


### PR DESCRIPTION
On VDB platforms, encfs is used for mounting cryptographic file-system. Encfs uses openssl for the encryption alogirthms. openssl uses APIs like RAND_bytes() to generate random numbers. RAND_bytes() API internally calls system call getrandom() which in order can either use HWRNG or PSRNG methods to generate random number.

Issue that we are facing is, during the boot encfs command hangs. After my investigation, I figured out that it hangs while trying to get random number. This is happening due to entropy source being empty. I am yet to figure out if we have HWRNG implemented which I believe is in the SoC itself. But most likely this is the case.

I'm basically trying to fix issues mentioned at
https://github.com/openssl/openssl/issues/10463
https://github.com/syslog-ng/syslog-ng/issues/3124 https://lwn.net/ml/linux-kernel/20190914122500.GA1425@darwi-home-pc/ https://lwn.net/Articles/800509/

This patch inserts bits in the pool if there isn't already available.

Inspired from commit
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=50ee7529ec4500c88f8664560770a7a1b65db72b

It works for me successfully in testing.

Signed-off-by: Sanjeev Chugh <schugh@alarm.com>